### PR TITLE
PasswordGrant: syntax error on invalid username fixed

### DIFF
--- a/website/oauth2.py
+++ b/website/oauth2.py
@@ -42,7 +42,7 @@ class AuthorizationCodeGrant(grants.AuthorizationCodeGrant):
 class PasswordGrant(grants.ResourceOwnerPasswordCredentialsGrant):
     def authenticate_user(self, username, password):
         user = User.query.filter_by(username=username).first()
-        if user.check_password(password):
+        if user is not None and user.check_password(password):
             return user
 
 


### PR DESCRIPTION
When using PasswordGrant and passing bad username to request (via CURL), the server gets syntax error:
`AttributeError: 'NoneType' object has no attribute 'check_password'`

I fixed it. Result of request now:
`{"error": "invalid_grant", "error_description": "Invalid \"username\" or \"password\" in request."}`