### PR TITLE
client ask for Auth on behalf of owner when owner got no session on auth server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.sqlite
 *.pyc
+venv/*

--- a/website/templates/authorize.html
+++ b/website/templates/authorize.html
@@ -1,5 +1,9 @@
-<p>{{grant.client.client_name}} is requesting:
+<p>The application <strong>{{grant.client.client_name}}</strong> is requesting:
 <strong>{{ grant.request.scope }}</strong>
+</p>
+
+<p>
+  from You - a.k.a. <strong>{{ user.username }}</strong>
 </p>
 
 <form action="" method="post">


### PR DESCRIPTION
when 3rd party request auth and resource owner is NOT LOGGED to the
Auth server, then the request should be redirected to the owner login page (on Auth server) at first. And after owner logged in, redirect resource owner back to the auth endpoint