### PR TITLE
Remove gen_salt in oauth2.py

### DIFF
--- a/website/oauth2.py
+++ b/website/oauth2.py
@@ -10,7 +10,6 @@ from authlib.integrations.sqla_oauth2 import (
 )
 from authlib.oauth2.rfc6749 import grants
 from authlib.oauth2.rfc7636 import CodeChallenge
-from werkzeug.security import gen_salt
 from .models import db, User
 from .models import OAuth2Client, OAuth2AuthorizationCode, OAuth2Token
 


### PR DESCRIPTION
gen_salt is imported but never used in oauth2.py