### PR TITLE
Create better alignment for client_info and client_metadata in home.html

### DIFF
--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -4,8 +4,14 @@
 
 {% for client in clients %}
 <pre>
-{{ client.client_info|tojson }}
-{{ client.client_metadata|tojson }}
+<strong>Client Info</strong>
+  {%- for key in client.client_info %}
+  <strong>{{ key }}: </strong>{{ client.client_info[key] }}
+  {%- endfor %}
+<strong>Client Metadata</strong>
+  {%- for key in client.client_metadata %}
+  <strong>{{ key }}: </strong>{{ client.client_metadata[key] }}
+  {%- endfor %}
 </pre>
 <hr>
 {% endfor %}


### PR DESCRIPTION
I created better alignment for client_info and client_metadata in home.html so that they are easier to read.

Previous:
![Previous client_info and client_metadata](https://user-images.githubusercontent.com/31149339/87218069-12fda900-c382-11ea-86df-2372aa99394d.png)

Current:
![Current client_info and client_metadata](https://user-images.githubusercontent.com/31149339/87218088-2dd01d80-c382-11ea-87e5-eae5912739a5.png)
