### PR TITLE
Update naming of consent request method

### DIFF
--- a/website/routes.py
+++ b/website/routes.py
@@ -98,7 +98,7 @@ def authorize():
         return redirect(url_for('website.routes.home', next=request.url))
     if request.method == 'GET':
         try:
-            grant = authorization.validate_consent_request(end_user=user)
+            grant = authorization.get_consent_grant(end_user=user)
         except OAuth2Error as error:
             return error.error
         return render_template('authorize.html', user=user, grant=grant)


### PR DESCRIPTION
From validate_consent_request to get_consent_grant

https://docs.authlib.org/en/latest/flask/2/api.html?highlight=validate_consent_request#authlib.integrations.flask_oauth2.AuthorizationServer.get_consent_grant


Solves this error
```
[2022-08-08 10:09:42,040] ERROR in app: Exception on /oauth/authorize [GET]
Traceback (most recent call last):
  File "/Users/u/.pyenv/versions/3.8.12/lib/python3.8/site-packages/flask/app.py", line 2525, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/u/.pyenv/versions/3.8.12/lib/python3.8/site-packages/flask/app.py", line 1822, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/u/.pyenv/versions/3.8.12/lib/python3.8/site-packages/flask/app.py", line 1820, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/u/.pyenv/versions/3.8.12/lib/python3.8/site-packages/flask/app.py", line 1796, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/Users/u/Development/example-oauth2-server/website/routes.py", line 101, in authorize
    grant = authorization.validate_consent_request(end_user=user)
AttributeError: 'AuthorizationServer' object has no attribute 'validate_consent_request'
```