### PR TITLE
update requirements.txt to use latest Authlib (fix issue #90)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Flask
 Flask-SQLAlchemy
-Authlib==0.14.3
+Authlib


### PR DESCRIPTION
This PR is to update `requirements.txt` to use the latest `Authlib`.
* The `example-oauth2-server` is not fully functional until this fix goes in.  For details and validation/resolution please see:  https://github.com/authlib/example-oauth2-server/issues/90#issuecomment-1304556901
* In addition to fixing the regression, this PR uses the latest `Authlib` (instead of pinning to a version)  to encourage keeping the example working across `Authlib` enhancements -- a useful attribute of an example.