### PR TITLE
Before_first_request deprecation fix

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -27,11 +27,10 @@ def create_app(config=None):
 
 
 def setup_app(app):
-    # Create tables if they do not exist already
-    @app.before_first_request
-    def create_tables():
-        db.create_all()
 
     db.init_app(app)
+    # Create tables if they do not exist already
+    with app.app_context():
+        db.create_all()
     config_oauth(app)
     app.register_blueprint(bp, url_prefix='')


### PR DESCRIPTION
When executing `flask run` the program throws an error: `AttributeError: 'Flask' object has no attribute 'before_first_request'. Did you mean: '_got_first_request'?`

I think this may be a fix :)